### PR TITLE
fix the value of target[0][action] line 65

### DIFF
--- a/ddqn.py
+++ b/ddqn.py
@@ -60,9 +60,10 @@ class DQNAgent:
             if done:
                 target[0][action] = reward
             else:
-                a = self.model.predict(next_state)[0]
+                # a = self.model.predict(next_state)[0]
                 t = self.target_model.predict(next_state)[0]
-                target[0][action] = reward + self.gamma * t[np.argmax(a)]
+                target[0][action] = reward + self.gamma * np.amax(t)
+                # target[0][action] = reward + self.gamma * t[np.argmax(a)]
             self.model.fit(state, target, epochs=1, verbose=0)
         if self.epsilon > self.epsilon_min:
             self.epsilon *= self.epsilon_decay


### PR DESCRIPTION
I have modified how is obtained the value of 
` target[0][action] =...`
because in the paper https://arxiv.org/abs/1312.5602, this value is obtained as 

> r_j + gamma * max_a'( Q_hat( state_{j+1} , a' ) )

and not as in the previous code as 

> r_j + gamma + Q_hat( state_{j+1} , argmax_a'( Q( state_{j+1} , a' ) )'

With this fix the algorithm is more stable.